### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "privacy_http_sdk"
 description = "Privacy HTTP SDK for Rust"
-homepage = "https://github.com/AI-Robotic-Labs/http-privacy"
+repository = "https://github.com/AI-Robotic-Labs/http-privacy"
 documentation = "https://docs.rs/privacy_http_sdk"
 license = "MIT"
 version = "1.0.5-beta"


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/91